### PR TITLE
Add initial Helm Chart for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+charts/
+kustomize/

--- a/.preview/chart-values/emojivoto.yaml
+++ b/.preview/chart-values/emojivoto.yaml
@@ -1,0 +1,15 @@
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - host: ${PREVIEWHQ_HOSTNAME}
+      paths:
+        - /
+  tls:
+   - secretName: tls-secret
+     hosts:
+       - ${PREVIEWHQ_CLUSTER_HOSTNAME}
+       - ${PREVIEWHQ_HOSTNAME}

--- a/.preview/config.yml
+++ b/.preview/config.yml
@@ -1,0 +1,11 @@
+
+images:
+  - name: web
+    buildargs:
+      svc_name: "emojivoto-web"
+  - name: voting-svc
+    buildargs:
+      svc_name: "emojivoto-voting-svc"
+  - name: emoji-svc
+    buildargs:
+      svc_name: "emojivoto-emoji-svc"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,55 @@
-FROM buoyantio/emojivoto-svc-base:v10
+FROM golang:1.13.8 as builder
+
+# Set necessary environmet variables needed for our image
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+
+RUN apt update \
+    && apt-get install -y --no-install-recommends \
+          autoconf \
+          automake \
+          libtool \
+          curl \
+          make \
+          g++ \
+          unzip \
+          protobuf-c-compiler
+
+ENV PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
+
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP && \
+  unzip -o $PROTOC_ZIP -d /usr/local bin/protoc && \
+  unzip -o $PROTOC_ZIP -d /usr/local 'include/*' && \
+  rm -f $PROTOC_ZIP
+
+RUN go get -u github.com/golang/protobuf/protoc-gen-go
+
+# Install the right "yarn"
+# This is only needed for the web build
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && apt-get install yarn -y
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+
+RUN make build
+
+# Copy all the built stuff into a smaller image
+FROM alpine
 
 ARG svc_name
 
-COPY $svc_name/target/ /usr/local/bin/
+COPY --from=builder /build/$svc_name/target /usr/local/bin/
 
 # ARG variables arent available for ENTRYPOINT
 ENV SVC_NAME $svc_name

--- a/charts/emojivoto/.helmignore
+++ b/charts/emojivoto/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/emojivoto/Chart.yaml
+++ b/charts/emojivoto/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: emojivoto
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+

--- a/charts/emojivoto/templates/NOTES.txt
+++ b/charts/emojivoto/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "emojivoto.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "emojivoto.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "emojivoto.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "emojivoto.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/emojivoto/templates/_helpers.tpl
+++ b/charts/emojivoto/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "emojivoto.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "emojivoto.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "emojivoto.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "emojivoto.labels" -}}
+helm.sh/chart: {{ include "emojivoto.chart" . }}
+{{ include "emojivoto.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "emojivoto.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "emojivoto.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "emojivoto.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "emojivoto.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/emojivoto/templates/emoji.yaml
+++ b/charts/emojivoto/templates/emoji.yaml
@@ -1,0 +1,62 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: emoji
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+# Todo: From when Preview injects imagePullSecrets appropriately
+imagePullSecrets:
+  - name: previewhq-registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emoji
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emoji-svc
+  template:
+    metadata:
+      labels:
+        app: emoji-svc
+        version: {{ .Values.image.tag }}
+    spec:
+      serviceAccountName: emoji
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: PROM_PORT
+          value: "8801"
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-emoji-svc
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: emoji-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        - containerPort: 8801
+          name: prom
+        resources:
+          requests:
+            cpu: 100m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emoji-svc
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: emoji-svc
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+  - name: prom
+    port: 8801
+    targetPort: 8801

--- a/charts/emojivoto/templates/ingress.yaml
+++ b/charts/emojivoto/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "emojivoto.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: "web-svc"
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/emojivoto/templates/tests/test-connection.yaml
+++ b/charts/emojivoto/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "emojivoto.fullname" . }}-test-connection"
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "emojivoto.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/emojivoto/templates/vote-bot.yaml
+++ b/charts/emojivoto/templates/vote-bot.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vote-bot
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote-bot
+  template:
+    metadata:
+      labels:
+        app: vote-bot
+        version: {{ .Values.image.tag }}
+    spec:
+      containers:
+      - command:
+        - emojivoto-vote-bot
+        env:
+        - name: WEB_HOST
+          value: web-svc:80
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-web
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: vote-bot
+        resources:
+          requests:
+            cpu: 10m

--- a/charts/emojivoto/templates/voting.yaml
+++ b/charts/emojivoto/templates/voting.yaml
@@ -1,0 +1,62 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: voting
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+# Todo: From when Preview injects imagePullSecrets appropriately
+imagePullSecrets:
+  - name: previewhq-registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: voting
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: voting-svc
+  template:
+    metadata:
+      labels:
+        app: voting-svc
+        version: {{ .Values.image.tag }}
+    spec:
+      serviceAccountName: voting
+      containers:
+      - env:
+        - name: GRPC_PORT
+          value: "8080"
+        - name: PROM_PORT
+          value: "8801"
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-voting-svc
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: voting-svc
+        ports:
+        - containerPort: 8080
+          name: grpc
+        - containerPort: 8801
+          name: prom
+        resources:
+          requests:
+            cpu: 100m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: voting-svc
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: voting-svc
+  ports:
+  - name: grpc
+    port: 8080
+    targetPort: 8080
+  - name: prom
+    port: 8801
+    targetPort: 8801

--- a/charts/emojivoto/templates/web.yaml
+++ b/charts/emojivoto/templates/web.yaml
@@ -1,0 +1,62 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: web
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+# Todo: From when Preview injects imagePullSecrets appropriately
+imagePullSecrets:
+  - name: previewhq-registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-svc
+  template:
+    metadata:
+      labels:
+        app: web-svc
+        version: {{ .Values.image.tag }}
+    spec:
+      serviceAccountName: web
+      containers:
+      - env:
+        - name: WEB_PORT
+          value: "8080"
+        - name: EMOJISVC_HOST
+          value: emoji-svc:8080
+        - name: VOTINGSVC_HOST
+          value: voting-svc:8080
+        - name: INDEX_BUNDLE
+          value: dist/index_bundle.js
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-web
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: web-svc
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 100m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+  labels:
+    {{- include "emojivoto.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: web-svc
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/charts/emojivoto/values.yaml
+++ b/charts/emojivoto/values.yaml
@@ -1,0 +1,73 @@
+# Default values for emojivoto.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: buoyantio/emojivoto
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: emojivoto.127.0.0.1.xip.io
+      paths: ["/"]
+  tls:
+    - secretName: tls-emojivoto.127.0.0.1.xip.io
+      commonName: emojivoto.127.0.0.1.xip.io
+      hosts:
+        - emojivoto.127.0.0.1.xip.io
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
-export IMAGE_TAG := v10
+export IMAGE_TAG := latest
 
 .PHONY: package protoc test
 
@@ -13,7 +13,7 @@ clean:
 protoc:
 	protoc -I .. ../proto/*.proto --go_out=plugins=grpc:gen
 
-package: protoc compile build-container
+package: protoc compile
 
 build-container:
 	docker build .. -t "buoyantio/$(svc_name):$(IMAGE_TAG)" --build-arg svc_name=$(svc_name)

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,5 @@ require (
 	google.golang.org/api v0.22.0 // indirect
 	google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84 // indirect
 	google.golang.org/grpc v1.29.1
+	google.golang.org/protobuf v1.21.0
 )


### PR DESCRIPTION
I still need to:

 - Swap docker builds to a multi-stage build (first stage builds protos,
 follow-on stages for each of the service images
 - Add a .preview config file and chart values (if necessary)